### PR TITLE
Integrate in the iCub Telemetry Server the network ping command via RPC port

### DIFF
--- a/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerStart.xml
+++ b/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerStart.xml
@@ -7,7 +7,7 @@
     </scripts>
     <node-interpreter value="project" />
     <envs>
-      <env name="NODE_DEBUG_OPPTION" value="debug" />
+      <env name="NODE_DEBUG_OPTION" value="debug" />
     </envs>
     <method v="2" />
   </configuration>

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -114,7 +114,7 @@ portRPCserver4sysCmds.onRead(function (cmdNparams) {
                         console.log('error: Missing round trip time');
                     }
                     else {
-                        console.log('stdout: ' + data);
+                        icubtelemetry.generateTelemetry(Date.now(),data,'ping');
                     }
                 }
                 onStderror = function (data) {

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -42,6 +42,9 @@ var getDataURIscheme = require('./getDataURIscheme');
 var expressWs = require('express-ws');
 expressWs(app);
 
+// Create a child process spawn for executing shell commands
+var spawn = require('child_process').spawn;
+
 // Create the servers
 var icubtelemetry = new ICubTelemetry();
 var realtimeServer = new RealtimeServer(icubtelemetry);
@@ -76,6 +79,21 @@ Object.keys(portInConfig).forEach(function (id) {
         default:
     }
     yarp.Network.connect(portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
+});
+
+// Run network ping as a network performance indicator
+var ping = spawn('ping',['-i 1','192.168.1.18']); // "ping" with 1s delay between ICMPs
+ping.stdout.on('data', function (data) {
+    console.log('stdout: '+data);
+});
+ping.stderr.on('data', function (data) {
+    console.log('stderr: '+data);
+});
+ping.on('error', function (error) {
+    console.log('error: '+error.message);
+});
+ping.on('close', function (code) {
+    console.log('stdout: '+code);
 });
 
 // Start history and realtime servers

--- a/iCubTelemVizServer/pingHandler.js
+++ b/iCubTelemVizServer/pingHandler.js
@@ -50,4 +50,4 @@ PingHandler.prototype.isOn = function () {
 
 module.exports = function () {
     return new PingHandler();
-};
+}

--- a/iCubTelemVizServer/pingHandler.js
+++ b/iCubTelemVizServer/pingHandler.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function PingHandler() {
+    // Create a child process spawn for executing shell commands
+    this.spawn = require('child_process').spawn;
+    this.processHandle = null;
+    // Create a parser
+    this.querystring = require('querystring');
+}
+
+PingHandler.prototype.start = function (period,targetHost,onStdout,onStderr,onError,onClose) {
+    if (this.isOn()) {
+        return {status: 'WARNING', err: 'ping session already ongoing.'};
+    }
+    else {
+        const embeddedThis = this;
+        // Start the process
+        let ping = this.spawn('ping', ['-i', period.toString(), targetHost]); // "ping" with 1s delay between ICMPs
+        // Set the output callbacks
+        ping.stdout.on('data', function (data) {
+            let parsedData = embeddedThis.querystring.parse(data.toString(),' ','=');
+            let parsedKeySet = new Set(Object.keys(parsedData));
+            if (parsedKeySet.has('time')) {
+                onStdout(parsedData.time);
+            }
+            else {
+                onStdout('-1');
+            }
+        });
+        ping.stderr.on('data', onStderr);
+        ping.on('error', onError);
+        ping.on('close', function (code) {
+            embeddedThis.processHandle = null;
+            onClose(code);
+        });
+
+        this.processHandle = ping;
+        return {status: 'OK', err: 'Process started.'};
+    }
+}
+
+PingHandler.prototype.stop = function () {
+    this.processHandle.kill();
+    return {status: 'OK', err: 'Process stopping...'};
+}
+
+PingHandler.prototype.isOn = function () {
+    return (this.processHandle != null);
+}
+
+module.exports = function () {
+    return new PingHandler();
+};


### PR DESCRIPTION
We shall integrate in the iCub Telemetry Server the network ping command to be triggered via RPC port.

- [x] Create the child process using the `spawn()` method from the **Node.JS** `child_process` module (Display the returned data and errors on the terminal). => https://github.com/dic-iit/yarp-openmct/issues/13#issuecomment-909603639
- [x] Create an RPC interface for triggering the ping command (the intent is to enable the ON/OFF toggling of the ping through a button on the web client control console). => https://github.com/dic-iit/yarp-openmct/issues/13#issuecomment-909613782 and https://github.com/ami-iit/yarp-openmct/issues/13#issuecomment-912637378
- [x] Generate asynchronously the Telemetry samples from the returned data (round-trip ping delay in milliseconds), ready to be sent to the OpenMCT visualizer at request. => https://github.com/ami-iit/yarp-openmct/issues/13#issuecomment-912645059