### PR TITLE
Add the battery status to the telemetry server and visualizer

### DIFF
--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -62,7 +62,8 @@ var portInConfig = {
     "sens.camLeftEye": {"yarpName":'/icubSim/camLeftEye', "localName":'/yarpjs/camLeftEye:i',"portType":'image'},
     "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'},
     "sens.leftLegEEwrench": {"yarpName":'/wholeBodyDynamics/left_leg/cartesianEndEffectorWrench:o', "localName":'/yarpjs/left_leg/cartesianEndEffectorWrench:i',"portType":'bottle'},
-    "sens.rightLegEEwrench": {"yarpName":'/wholeBodyDynamics/right_leg/cartesianEndEffectorWrench:o', "localName":'/yarpjs/right_leg/cartesianEndEffectorWrench:i',"portType":'bottle'}
+    "sens.rightLegEEwrench": {"yarpName":'/wholeBodyDynamics/right_leg/cartesianEndEffectorWrench:o', "localName":'/yarpjs/right_leg/cartesianEndEffectorWrench:i',"portType":'bottle'},
+    "sens.batteryStatus": {"yarpName":'/icubSim/batteryStatus', "localName":'/yarpjs/batteryStatus:i',"portType":'bottle'}
 };
 
 // Open the ports, register read callback functions, connect the ports

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -63,7 +63,7 @@ var portInConfig = {
     "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'},
     "sens.leftLegEEwrench": {"yarpName":'/wholeBodyDynamics/left_leg/cartesianEndEffectorWrench:o', "localName":'/yarpjs/left_leg/cartesianEndEffectorWrench:i',"portType":'bottle'},
     "sens.rightLegEEwrench": {"yarpName":'/wholeBodyDynamics/right_leg/cartesianEndEffectorWrench:o', "localName":'/yarpjs/right_leg/cartesianEndEffectorWrench:i',"portType":'bottle'},
-    "sens.batteryStatus": {"yarpName":'/icubSim/batteryStatus', "localName":'/yarpjs/batteryStatus:i',"portType":'bottle'}
+    "sens.batteryStatus": {"yarpName":'/icubSim/battery/data:o', "localName":'/yarpjs/battery/data:i',"portType":'bottle'}
 };
 
 // Open the ports, register read callback functions, connect the ports

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -112,6 +112,7 @@ ICubTelemetry.prototype.updateState = function (id,sensorSample) {
             this.state[id].charge = sensorSample[2];
             this.state[id].temperature = sensorSample[3];
             this.state[id].status = sensorSample[4];
+            break;
         default:
             this.state[id] = sensorSample;
     }

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -33,6 +33,9 @@ function ICubTelemetry() {
         "sens.rightLegEEwrench": {
             "force": {"x": 0, "y": 0, "z": 0},
             "torque": {"x": 0, "y": 0, "z": 0}
+        },
+        "sens.batteryStatus": {
+            "voltage": 0, "current": 0, "charge": 0, "temperature": 0, "status": 0
         }
     };
 
@@ -103,6 +106,12 @@ ICubTelemetry.prototype.updateState = function (id,sensorSample) {
             this.state[id].torque.y = sensorSample[4];
             this.state[id].torque.z = sensorSample[5];
             break;
+        case "sens.batteryStatus":
+            this.state[id].voltage = sensorSample[0];
+            this.state[id].current = sensorSample[1];
+            this.state[id].charge = sensorSample[2];
+            this.state[id].temperature = sensorSample[3];
+            this.state[id].status = sensorSample[4];
         default:
             this.state[id] = sensorSample;
     }
@@ -118,6 +127,7 @@ ICubTelemetry.prototype.generateTelemetry = function (timestamp,value,id) {
         case "sens.leftLegState":
         case "sens.leftLegEEwrench":
         case "sens.rightLegEEwrench":
+        case "sens.batteryStatus":
             var telemetrySample = this.flatten({timestamp: timestamp, value: value, id: id});
             break;
         default:

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -401,6 +401,66 @@
           }
         }
       ]
+    },
+    {
+      "name": "Battery State",
+      "key": "sens.batteryStatus",
+      "values": [
+        {
+          "key": "value.voltage",
+          "name": "Voltage",
+          "units": "Volts",
+          "format": "float",
+          "hints": {
+            "range": 1
+          }
+        },
+        {
+          "key": "value.current",
+          "name": "Current",
+          "units": "Amperes",
+          "format": "float",
+          "hints": {
+            "range":2
+          }
+        },
+        {
+          "key": "value.charge",
+          "name": "State of Charge",
+          "units": "%",
+          "format": "float",
+          "hints": {
+            "range": 3
+          }
+        },
+        {
+          "key": "value.temperature",
+          "name": "Temperature",
+          "units": "ºC",
+          "format": "float",
+          "hints": {
+            "range": 4
+          }
+        },
+        {
+          "key": "value.status",
+          "name": "Operation State",
+          "units": "",
+          "format": "float",
+          "hints": {
+            "range": 5
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Implements #14 :
- Create a reader port `/yarpjs/battery/data:i` and connect it to the port `/icubSim/battery/data:o`.
- The telemetry server reads the data from `/yarpjs/battery/data:i` and generates the telemetry data from it.
- Add battery status entry to the OpenMCT visualizer (update the telemetry JSON dictonary).