### PR TITLE
Fix the telemetry server URI used on the client side and do some minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Depending on which robot data you wish to visualize or operation you wish to run
     ```
     conda activate icubtelemenv
     ```
-3. Open the default comfiguration file `<yarp-openmct-root-folder>/config/default.json`. This JSON formatted file holds the ports configuration, the ports prefix and the servers configuration.
+3. Open the default configuration file `<yarp-openmct-root-folder>/config/default.json`. This JSON formatted file holds the ports configuration, the ports prefix and the servers configuration.
    <details>
    <summary>[Servers Default Configuration Parameters]</summary>
    

--- a/common/utils.js
+++ b/common/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*
+/**
  * Signal string to code conversion from the POSIX standard
  *
  *      1       HUP (hang up)
@@ -22,29 +22,48 @@ const signalName2codeMap = {
     SIGTERM:  15
 };
 
-/*
+/**
  * Signal Exits codes
  *
  * (Refer to https://nodejs.org/api/process.html#exit-codes)
  *
- * >128 Signal Exits: If Node.js receives a fatal signal such as SIGKILL or SIGHUP, then its exit code will be 128 plus the value of the signal code. This is a standard POSIX practice, since exit codes are defined to be 7-bit integers, and signal exits set the high-order bit, and then contain the value of the signal code. For example, signal SIGABRT has value 6, so the expected exit code will be 128 + 6, or 134.
+ * @param {string} signalName - 'SIGINT', 'SIGQUIT', 'SIGTERM', ...
+ * @returns {number} Signal Exits (>128): If Node.js receives a fatal signal such as SIGKILL or SIGHUP, then its
+ * exit code will be 128 plus the value of the signal code. This is a standard POSIX practice, since exit codes are
+ * defined to be 7-bit integers, and signal exits set the high-order bit, and then contain the value of the signal
+ * code. For example, signal SIGABRT has value 6, so the expected exit code will be 128 + 6, or 134.
  */
 function signalName2exitCodeMap (signalName) {
     return 128+signalName2codeMap[signalName];
 }
 
-/*
+/**
  * A counter
  */
-function MyCounter() {
+function MyCounter () {
     this.counter = 0;
     this.incr = () => {this.counter += 1; return this.counter};
     this.decr = () => {this.counter -= 1; return this.counter};
     this.reset = () => {this.counter= 0};
 }
 
+/**
+ * Returns a string which evaluation defines a variable and sets its value to the stringified JSON object. This
+ * function produces the same result as what would be expected from `res.jsonp` (refer to
+ * https://expressjs.com/en/5x/api.html#res.jsonp).
+ *
+ * @param {object} jsonObject - input object to stringify.
+ * @param {string} objectName - JSON string name in the scope where the eventual script is run.
+ * @return {string} - script to be eventually run on a remote machine.
+ */
+function jsonExportScript (jsonObject,objectName) {
+    return `var ${objectName} = ${JSON.stringify(jsonObject)}`;
+}
+
+
 module.exports = {
     signalName2codeMap: signalName2codeMap,
     signalName2exitCodeMap: signalName2exitCodeMap,
-    MyCounter: MyCounter
+    MyCounter: MyCounter,
+    jsonExportScript: jsonExportScript
 };

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,6 @@
 {
     "robotYarpPortPrefix": "/icubSim",
+    "localYarpPortPrefix": "/yarpjs",
     "telemVizServer": {
         "host": "localhost",
         "port": 8081
@@ -15,37 +16,37 @@
     "portInConfig": {
         "sens.imu": {
             "yarpName": "${this.robotYarpPortPrefix}/inertial",
-            "localName": "/yarpjs/inertial:i",
+            "localName": "${this.localYarpPortPrefix}/inertial:i",
             "portType": "bottle"
         },
         "sens.leftLegState": {
             "yarpName": "${this.robotYarpPortPrefix}/left_leg/stateExt:o",
-            "localName": "/yarpjs/left_leg/stateExt:o",
+            "localName": "${this.localYarpPortPrefix}/left_leg/stateExt:o",
             "portType": "bottle"
         },
         "sens.camLeftEye": {
             "yarpName": "${this.robotYarpPortPrefix}/camLeftEye",
-            "localName": "/yarpjs/camLeftEye:i",
+            "localName": "${this.localYarpPortPrefix}/camLeftEye:i",
             "portType": "image"
         },
         "sens.camRightEye": {
             "yarpName": "${this.robotYarpPortPrefix}/camRightEye",
-            "localName": "/yarpjs/camRightEye:i",
+            "localName": "${this.localYarpPortPrefix}/camRightEye:i",
             "portType": "image"
         },
         "sens.leftFootEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o",
-            "localName": "/yarpjs/left_foot/cartesianEndEffectorWrench:i",
+            "localName": "${this.localYarpPortPrefix}/left_foot/cartesianEndEffectorWrench:i",
             "portType": "bottle"
         },
         "sens.rightFootEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o",
-            "localName": "/yarpjs/right_foot/cartesianEndEffectorWrench:i",
+            "localName": "${this.localYarpPortPrefix}/right_foot/cartesianEndEffectorWrench:i",
             "portType": "bottle"
         },
         "sens.batteryStatus": {
             "yarpName": "${this.robotYarpPortPrefix}/battery/data:o",
-            "localName": "/yarpjs/battery/data:i",
+            "localName": "${this.localYarpPortPrefix}/battery/data:i",
             "portType": "bottle"
         }
     }

--- a/config/processedDefault.js
+++ b/config/processedDefault.js
@@ -27,8 +27,8 @@ let processedConfig = traverse(config);
  * - "this" is the root object "config",
  * - "key1.key2...keyN" is the path to the nested field defining the variable.
  *
- * @param nestedObject
- * @returns nestedOject
+ * @param {object} nestedObject
+ * @returns {object} evaluatedNestedOject
  */
 function traverse (nestedObject) {
     Object.keys(nestedObject).forEach((k) => {

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -163,7 +163,7 @@ const telemServer = app.listen(portTelemetryRespOrigin, config.telemVizServer.ho
 });
 
 // Start the control console server
-const consoleServer = http.listen(3000, config.consoleServer.host, function(){
+const consoleServer = http.listen(config.consoleServer.port, config.consoleServer.host, function(){
   console.log('Control Console Server listening on http://' + consoleServer.address().address + ':' + consoleServer.address().port);
 });
 

--- a/openmctStaticServer/historical-telemetry-plugin.js
+++ b/openmctStaticServer/historical-telemetry-plugin.js
@@ -2,14 +2,14 @@
  * Basic historical telemetry plugin.
  */
 
-function HistoricalTelemetryPlugin() {
+function HistoricalTelemetryPlugin(telemServerHost,telemServerPort) {
     return function install (openmct) {
         var provider = {
             supportsRequest: function (domainObject) {
                 return domainObject.type === 'icubsensor.telemetry';
             },
             request: function (domainObject, options) {
-                var url = 'http://localhost:8081/history/' +
+                var url = 'http://' + telemServerHost + ':' + telemServerPort + '/history/' +
                     domainObject.identifier.key +
                     '?start=' + options.start +
                     '&end=' + options.end;

--- a/openmctStaticServer/index.html
+++ b/openmctStaticServer/index.html
@@ -7,6 +7,7 @@
     <script src="dictionary-plugin.js"></script>
     <script src="historical-telemetry-plugin.js"></script>
     <script src="realtime-telemetry-plugin.js"></script>
+    <script src="config/processedDefault.json"></script>
     <link rel="stylesheet" href="node_modules/openmct/dist/espressoTheme.css">
 </head>
 <body>
@@ -18,9 +19,11 @@
         openmct.time.clock('local', {start: -ONE_MINUTE, end: 0});
         openmct.time.timeSystem('utc');
 
+        let telemServerHost = processedConfig.telemVizServer.host;
+        let telemServerPort = processedConfig.telemVizServer.port;
         openmct.install(DictionaryPlugin());
-        openmct.install(HistoricalTelemetryPlugin());
-        openmct.install(RealtimeTelemetryPlugin());
+        openmct.install(HistoricalTelemetryPlugin(telemServerHost,telemServerPort));
+        openmct.install(RealtimeTelemetryPlugin(telemServerHost,telemServerPort));
 
         openmct.start();
     </script>

--- a/openmctStaticServer/realtime-telemetry-plugin.js
+++ b/openmctStaticServer/realtime-telemetry-plugin.js
@@ -1,9 +1,9 @@
 /**
  * Basic Realtime telemetry plugin using websockets.
  */
-function RealtimeTelemetryPlugin() {
+function RealtimeTelemetryPlugin(telemServerHost,telemServerPort) {
     return function (openmct) {
-        var socket = new WebSocket('ws://localhost:8081' + '/realtime/');
+        var socket = new WebSocket('ws://' + telemServerHost + ':' + telemServerPort + '/realtime/');
         var listener = {};
 
         socket.onmessage = function (event) {

--- a/openmctStaticServer/server.js
+++ b/openmctStaticServer/server.js
@@ -4,6 +4,7 @@
 
 // Import main configuration
 config = require('../config/processedDefault');
+jsonExportScript = (require('../common/utils')).jsonExportScript;
 
 // Send the process PID back to the parent through the IPC channel
 const OpenMctServerHandlerChildProc = require('./openMctServerHandlerChildProc');
@@ -16,10 +17,16 @@ const app = require('express')();
 expressWs(app);
 
 const staticServer = new StaticServer();
+// Process default server configuration requests
+app.get('/config/processedDefault.json', function(req, res){
+    console.log('processedDefault.json requested!');
+    res.send(jsonExportScript(config,'processedConfig'));
+});
+// Route static server
 app.use('/', staticServer);
-const port = process.env.PORT || config.openmctStaticServer.port;
 
 // Start the server
+const port = process.env.PORT || config.openmctStaticServer.port;
 vizServer = app.listen(port, config.openmctStaticServer.host, function () {
     console.log('Visualizer Console Server (Open MCT based) listening on http://' + vizServer.address().address + ':' + vizServer.address().port);
 });

--- a/openmctStaticServer/static-server.js
+++ b/openmctStaticServer/static-server.js
@@ -4,6 +4,7 @@ function StaticServer() {
     var router = express.Router();
 
     router.use('/', express.static(__dirname));
+    router.use('/config', express.static(__dirname + '/../config'));
 
     return router
 }


### PR DESCRIPTION
- Do some minor refactoring using JSDoc format (https://jsdoc.app/).
- Defined `jsonExportScript` which produces the same result as what would be expected
  from `res.jsonp` (https://expressjs.com/en/5x/api.html#res.jsonp,https://www.w3schools.com/js/js_json_jsonp.asp).
- Fix the telemetry server URI used on the client side in the `HistoricalTelemetryPlugin`
  and `RealtimeTelemetryPlugin` plugins.
- Process any GET request from the client browser to retrieve the JSON configuration "file",
  which is then sent as a JSON stringified configuration used to propagate the servers
  configuration.

Note on JSONP - from https://www.w3schools.com/js/js_json_jsonp.asp:
Requesting a file from another domain can cause problems, due to cross-domain policy.
Requesting an external script from another domain does not have this problem.
JSONP uses this advantage, and request files using the script tag instead of the XMLHttpRequest object.