### PR TITLE
Upgrade Open-MCT dependency to release 1.7.8

### DIFF
--- a/openmctStaticServer/index.html
+++ b/openmctStaticServer/index.html
@@ -2,23 +2,44 @@
 <html>
 <head>
     <title>iCub Telemetry Visualizer (Open MCT based)</title>
-    <script src="node_modules/openmct/dist/openmct.js"></script>
+    <script src="openmctdist/openmct.js"></script>
     <script src="lib/http.js"></script>
     <script src="dictionary-plugin.js"></script>
     <script src="historical-telemetry-plugin.js"></script>
     <script src="realtime-telemetry-plugin.js"></script>
     <script src="config/processedDefault.json"></script>
-    <link rel="stylesheet" href="node_modules/openmct/dist/espressoTheme.css">
+    <link rel="stylesheet" href="openmctdist/espressoTheme.css">
 </head>
 <body>
     <script>
+        // Open MCT native plugins
         openmct.install(openmct.plugins.LocalStorage());
+        openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
+        openmct.install(openmct.plugins.PlanLayout());
+        openmct.install(openmct.plugins.Timeline());
+        openmct.install(openmct.plugins.Hyperlink());
         openmct.install(openmct.plugins.UTCTimeSystem());
         const ONE_MINUTE = 60 * 1000;
+        openmct.install(openmct.plugins.SummaryWidget());
+        openmct.install(openmct.plugins.Notebook());
+        openmct.install(openmct.plugins.LADTable());
+        openmct.install(openmct.plugins.Filters(['table', 'telemetry.plot.overlay']));
+        openmct.install(openmct.plugins.ObjectMigration());
+        openmct.install(openmct.plugins.ClearData(
+            ['table', 'telemetry.plot.overlay', 'telemetry.plot.stacked'],
+            {indicator: true}
+        ));
+        openmct.install(openmct.plugins.Clock({ enableClockIndicator: true }));
+
         openmct.time.clock('local', {start: -ONE_MINUTE, end: 0});
         openmct.time.timeSystem('utc');
 
+        // For development use only (signal, state and image generator)
+        openmct.install(openmct.plugins.Generator());
+        openmct.install(openmct.plugins.ExampleImagery());
+
+        // Local plugins
         let telemServerHost = processedConfig.telemVizServer.host;
         let telemServerPort = processedConfig.telemVizServer.port;
         openmct.install(DictionaryPlugin());

--- a/openmctStaticServer/package-lock.json
+++ b/openmctStaticServer/package-lock.json
@@ -267,8 +267,8 @@
       }
     },
     "openmct": {
-      "version": "git+https://github.com/nasa/openmct.git#a40867d5443963a2b7d4f1b69607593071a1673a",
-      "from": "git+https://github.com/nasa/openmct.git"
+      "version": "git+https://github.com/nasa/openmct.git#ab7e2c57470d3c6076459ad7e3eaa1883cc3b8b0",
+      "from": "git+https://github.com/nasa/openmct.git#1.7.8"
     },
     "parseurl": {
       "version": "1.3.3",

--- a/openmctStaticServer/package.json
+++ b/openmctStaticServer/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
-    "openmct": "https://github.com/nasa/openmct.git",
+    "openmct": "https://github.com/nasa/openmct.git#1.7.8",
     "ws": "^7.2.0"
   },
   "repository": {

--- a/openmctStaticServer/static-server.js
+++ b/openmctStaticServer/static-server.js
@@ -5,6 +5,7 @@ function StaticServer() {
 
     router.use('/', express.static(__dirname));
     router.use('/config', express.static(__dirname + '/../config'));
+    router.use('/openmctdist', express.static(__dirname + '/node_modules/openmct/dist'));
 
     return router
 }


### PR DESCRIPTION
- Refer to https://github.com/ami-iit/yarp-openmct/issues/70, https://github.com/ami-iit/yarp-openmct/issues/81 and Open-MCT release https://github.com/nasa/openmct/releases/tag/1.7.8.
- Installed the dependency running:
    1. cd openmctStaticServer
    2. npm install --save-exact
    3. npm clean-install
- "npm clean-install" installs the project from a clean slate. The differences between this command and "install" are mainly:
  (from command "npm help clean-install")
    - The    project   must   have   an   existing   package-lock.json   or npm-shrinkwrap.json.
    - If dependencies in the package lock  do  not  match  those  in  package.json,  npm  ci  will  exit with an error, instead of updating the package lock.
    - npm ci can only install entire projects at a time: individual  dependencies cannot be added with this command.
    - If  a  node_modules  is  already  present,  it  will be automatically removed before npm ci begins its install.
    - It will never write to package.json  or  any  of  the  package-locks: installs are essentially frozen.
- The package-lock.json was committed after step 2.