### PR TITLE
Make the dependency `openmct` point to the forked repository in order to integrate IIT's fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "YarpJS": {
-      "version": "git+https://github.com/robotology/yarp.js.git#d2e4609c5115544c3837eb36fa38065aa06a343f",
+      "version": "git+https://github.com/robotology/yarp.js.git#08c9c2cd6b6957f45ffb58779bc998252d7c5269",
       "from": "git+https://github.com/robotology/yarp.js.git",
       "requires": {
         "cmake-js": "^6.3.0",
@@ -1091,8 +1091,8 @@
       }
     },
     "openmct": {
-      "version": "git+https://github.com/nasa/openmct.git#ab7e2c57470d3c6076459ad7e3eaa1883cc3b8b0",
-      "from": "git+https://github.com/nasa/openmct.git#1.7.8"
+      "version": "git+https://github.com/ami-iit/openmct.git#7e67bdba9ff7d6c4a98fa952ce484b3d0f474584",
+      "from": "git+https://github.com/ami-iit/openmct.git#fix/imagery-flickering"
     },
     "options": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "socket.io": "1.5.1",
     "socket.io-stream": "latest",
     "YarpJS": "https://github.com/robotology/yarp.js",
-    "openmct": "https://github.com/nasa/openmct.git#1.7.8",
+    "openmct": "https://github.com/ami-iit/openmct.git#1.7.8-iit",
     "ws": "^7.2.0"
   },
   "repository": {


### PR DESCRIPTION
Dependency now points to https://github.com/ami-iit/openmct/tree/1.7.8-iit.

Fixes #103 .