### PR TITLE
Add the possibility to visualize the YarpTextLogging from any logged process

### DIFF
--- a/common/openMctServerHandlerBase.js
+++ b/common/openMctServerHandlerBase.js
@@ -8,4 +8,13 @@ function OpenMctServerHandlerBase(outputCallback,errorCallback) {
 OpenMctServerHandlerBase.prototype.RUNNING = 0;
 OpenMctServerHandlerBase.prototype.CLOSING = 1;
 
-module.exports = OpenMctServerHandlerBase;
+// Supported Child->Parent commands
+class Child2ParentCommands {
+    static RefreshRegexpConnections = 0;
+}
+Object.freeze(Child2ParentCommands);
+
+module.exports = {
+    OpenMctServerHandlerBase,
+    Child2ParentCommands
+};

--- a/common/utils.js
+++ b/common/utils.js
@@ -118,7 +118,7 @@ function evalTemplateLiteralInJSON(jsonObjectWithTemplateLiterals, ...args) {
                     nestedObject[k] = traverse(nestedObject[k]);
                     break;
                 case "string":
-                    if (nestedObject[k].includes("$")) {
+                    if (nestedObject[k].match(/.*\${.+}.*/i) !== null) {
                         nestedObject[k] = templateLiteralEvalof(nestedObject[k]);
                     }
                     break;

--- a/common/utils.js
+++ b/common/utils.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var yarp = require('YarpJS');
+
 /**
  * Signal string to code conversion from the POSIX standard
  *
@@ -135,7 +137,9 @@ function evalTemplateLiteralInJSON(jsonObjectWithTemplateLiterals, ...args) {
 
 /**
  * Generates the values template blocks (generatedValuesBase) from the parameters in valuesTemplateGeneratorParams.
- * @type {{MyCounter: MyCounter, jsonExportScript: (function(Object, string): string), signalName2exitCodeMap: (function(string)), signalName2codeMap: {SIGQUIT: number, SIGINT: number, SIGALRM: number, SIGHUP: number, SIGABRT: number, SIGTERM: number, SIGKILL: number}, evalTemplateLiteralInJSON: (function(Object): Object)}}
+ *
+ * @param {object} dictionary2expand - JSON dictionary with the parameters for generating the generatedValuesBase blocks.
+ * @returns {object} - expanded dictionary.
  */
 function expandTelemetryDictionary(dictionary2expand) {
     // Run a first interpolation
@@ -170,11 +174,27 @@ function expandTelemetryDictionary(dictionary2expand) {
     return dictionary2expand;
 }
 
+/**
+ * Convert Bottle from string to JSON format
+ *
+ * @param {string} bottleAsString - JSON dictionary with the parameters for generating the generatedValuesBase blocks.
+ * @returns {object} - JSON formatted object.
+ */
+function yarpBottleString2JSON(bottleAsString) {
+    let bottleAsJSON = {};
+    let bottleAsNestedArray = yarp.Bottle().fromString(bottleAsString).toArray();
+    bottleAsNestedArray.forEach((elem) => {
+        bottleAsJSON[elem[0]] = elem[1];
+    });
+    return bottleAsJSON;
+}
+
 module.exports = {
     signalName2codeMap: signalName2codeMap,
     signalName2exitCodeMap: signalName2exitCodeMap,
     MyCounter: MyCounter,
     jsonExportScript: jsonExportScript,
     evalTemplateLiteralInJSON: evalTemplateLiteralInJSON,
-    expandTelemetryDictionary: expandTelemetryDictionary
+    expandTelemetryDictionary: expandTelemetryDictionary,
+    yarpBottleString2JSON: yarpBottleString2JSON
 };

--- a/common/yarpNameListHandler.js
+++ b/common/yarpNameListHandler.js
@@ -1,0 +1,47 @@
+"use strict";
+
+function YarpNameListHandler() {
+    // Create a child process spawn for executing shell commands
+    this.spawn = require('child_process').spawn;
+    this.yarpNameListprocHdl = null;
+    // Create a parser
+    this.querystring = require('querystring');
+}
+
+YarpNameListHandler.prototype.run = function (prefix,onStdout,onStdinf,onStderr) {
+    if (this.isOn()) {
+        return Promise.reject('Yarp command already running!');
+    } else {
+        return new Promise(function (resolve,reject) {
+            // Spawn the command process asynchronously
+            let procHdl = this.spawn('yarp', ['name', 'list', prefix.toString()]);
+            // Set the output callbacks
+            procHdl.stdout.on('data', function (data) {
+                onStdout(data);
+            });
+            procHdl.stderr.on('data', onStderr);
+            procHdl.on('spawn', function (code) {
+                this.yarpNameListprocHdl = procHdl;
+                onStdinf('Yarp command successfully started...');
+            }.bind(this));
+            procHdl.on('error', function (error) {
+                reject(error);
+            });
+            procHdl.on('close', function (code) {
+                this.yarpNameListprocHdl = null;
+                resolve(code);
+            }.bind(this));
+        }.bind(this));
+    }
+}
+
+YarpNameListHandler.prototype.kill = function () {
+    this.yarpNameListprocHdl.kill();
+    return {status: 'DELAYED_REPLY', err: 'Process stopping...'};
+}
+
+YarpNameListHandler.prototype.isOn = function () {
+    return (this.yarpNameListprocHdl != null);
+}
+
+module.exports = YarpNameListHandler;

--- a/conf/servers.json
+++ b/conf/servers.json
@@ -22,7 +22,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.headIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/head/inertials/measures:o",
@@ -31,7 +32,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftArmIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/left_arm/imu/measures:o",
@@ -40,7 +42,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightArmIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/right_arm/imu/measures:o",
@@ -49,7 +52,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftLegIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/left_leg/imu/measures:o",
@@ -58,7 +62,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightLegIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/right_leg/imu/measures:o",
@@ -67,7 +72,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftFootIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/left_foot/imu/measures:o",
@@ -76,7 +82,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightFootIMU": {
             "yarpName": "${this.robotYarpPortPrefix}/right_foot/imu/measures:o",
@@ -85,7 +92,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftLegJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/left_leg/stateExt:o",
@@ -94,7 +102,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightLegJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/right_leg/stateExt:o",
@@ -103,7 +112,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftArmJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/left_arm/stateExt:o",
@@ -112,7 +122,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightArmJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/right_arm/stateExt:o",
@@ -121,7 +132,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.torsoJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/torso/stateExt:o",
@@ -130,7 +142,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.headJointState": {
             "yarpName": "${this.robotYarpPortPrefix}/head/stateExt:o",
@@ -139,7 +152,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.camLeftEye": {
             "yarpName": "${this.robotYarpPortPrefix}/camLeftEye",
@@ -148,7 +162,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.camRightEye": {
             "yarpName": "${this.robotYarpPortPrefix}/camRightEye",
@@ -157,7 +172,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftArmEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_arm/cartesianEndEffectorWrench:o",
@@ -166,7 +182,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightArmEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_arm/cartesianEndEffectorWrench:o",
@@ -175,7 +192,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftUpperLegEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_upper_leg/cartesianEndEffectorWrench:o",
@@ -184,7 +202,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftLowerLegEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_lower_leg/cartesianEndEffectorWrench:o",
@@ -193,7 +212,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightUpperLegEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_upper_leg/cartesianEndEffectorWrench:o",
@@ -202,7 +222,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightLowerLegEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_lower_leg/cartesianEndEffectorWrench:o",
@@ -211,7 +232,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftFootFrontEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_foot_front/cartesianEndEffectorWrench:o",
@@ -220,7 +242,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftFootRearEEwrench": {
             "yarpName": "/wholeBodyDynamics/left_foot_rear/cartesianEndEffectorWrench:o",
@@ -229,7 +252,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightFootFrontEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_foot_front/cartesianEndEffectorWrench:o",
@@ -238,7 +262,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightFootRearEEwrench": {
             "yarpName": "/wholeBodyDynamics/right_foot_rear/cartesianEndEffectorWrench:o",
@@ -247,7 +272,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftArmFT": {
             "yarpName": "${this.robotYarpPortPrefix}/left_arm/measures:o",
@@ -256,7 +282,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightArmFT": {
             "yarpName": "${this.robotYarpPortPrefix}/right_arm/measures:o",
@@ -265,7 +292,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftLegHipFT": {
             "yarpName": "${this.robotYarpPortPrefix}/left_leg_hip/measures:o",
@@ -274,7 +302,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightLegHipFT": {
             "yarpName": "${this.robotYarpPortPrefix}/right_leg_hip/measures:o",
@@ -283,7 +312,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.leftFootHeelTiptoeFTs": {
             "yarpName": "${this.robotYarpPortPrefix}/left_foot_heel_tiptoe/measures:o",
@@ -292,7 +322,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.rightFootHeelTiptoeFTs": {
             "yarpName": "${this.robotYarpPortPrefix}/right_foot_heel_tiptoe/measures:o",
@@ -301,7 +332,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "sens.batteryStatus": {
             "yarpName": "${this.robotYarpPortPrefix}/battery/data:o",
@@ -310,7 +342,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "walkingController.logger": {
             "yarpName": "/walking-coordinator/logger/data:o",
@@ -319,7 +352,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "vectorCollection"
-            }
+            },
+            "sourceSync": "localTimer"
         },
         "yarplogger.yarpRobotInterface": {
             "yarpName": "/log/iiticublap199/yarprobotinterfa[yarprobotinterface]/1205",
@@ -328,7 +362,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "yarpPort"
         },
         "yarplogger.walkingModule": {
             "yarpName": "/log/iiticublap199/WalkingModule-0.[walkingModule]/1470",
@@ -337,7 +372,8 @@
             "parser": {
                 "type": "internal",
                 "outputFormat": "fromId"
-            }
+            },
+            "sourceSync": "yarpPort"
         }
     }
 }

--- a/conf/servers.json
+++ b/conf/servers.json
@@ -320,6 +320,24 @@
                 "type": "internal",
                 "outputFormat": "vectorCollection"
             }
+        },
+        "processTextLogging.yarpRobotInterface": {
+            "yarpName": "/log/iiticublap199/yarprobotinterfa[yarprobotinterface]/1205",
+            "localName": "${this.localYarpPortPrefix}/proc-yarprobotinterface-yarptextlogging:i",
+            "portType": "bottle",
+            "parser": {
+                "type": "internal",
+                "outputFormat": "fromId"
+            }
+        },
+        "processTextLogging.walkingModule": {
+            "yarpName": "/log/iiticublap199/WalkingModule-0.[walkingModule]/1470",
+            "localName": "${this.localYarpPortPrefix}/proc-walkingmodule-yarptextlogging:i",
+            "portType": "bottle",
+            "parser": {
+                "type": "internal",
+                "outputFormat": "fromId"
+            }
         }
     }
 }

--- a/conf/servers.json
+++ b/conf/servers.json
@@ -321,7 +321,7 @@
                 "outputFormat": "vectorCollection"
             }
         },
-        "processTextLogging.yarpRobotInterface": {
+        "yarplogger.yarpRobotInterface": {
             "yarpName": "/log/iiticublap199/yarprobotinterfa[yarprobotinterface]/1205",
             "localName": "${this.localYarpPortPrefix}/proc-yarprobotinterface-yarptextlogging:i",
             "portType": "bottle",
@@ -330,7 +330,7 @@
                 "outputFormat": "fromId"
             }
         },
-        "processTextLogging.walkingModule": {
+        "yarplogger.walkingModule": {
             "yarpName": "/log/iiticublap199/WalkingModule-0.[walkingModule]/1470",
             "localName": "${this.localYarpPortPrefix}/proc-walkingmodule-yarptextlogging:i",
             "portType": "bottle",

--- a/conf/servers.json
+++ b/conf/servers.json
@@ -356,7 +356,7 @@
             "sourceSync": "localTimer"
         },
         "yarplogger.yarpRobotInterface": {
-            "yarpName": "/log/iiticublap199/yarprobotinterfa[yarprobotinterface]/1205",
+            "yarpName": "@{^\\/log\\/.*\\[yarprobotinterface\\].*$}",
             "localName": "${this.localYarpPortPrefix}/proc-yarprobotinterface-yarptextlogging:i",
             "portType": "bottle",
             "parser": {
@@ -366,7 +366,7 @@
             "sourceSync": "yarpPort"
         },
         "yarplogger.walkingModule": {
-            "yarpName": "/log/iiticublap199/WalkingModule-0.[walkingModule]/1470",
+            "yarpName": "@{\\[walkingModule\\]}",
             "localName": "${this.localYarpPortPrefix}/proc-walkingmodule-yarptextlogging:i",
             "portType": "bottle",
             "parser": {

--- a/iCubTelemVizServer/configHandler.js
+++ b/iCubTelemVizServer/configHandler.js
@@ -22,7 +22,9 @@ function ConfigHandler(configFile) {
 ConfigHandler.prototype.matchRegexpYarpPortNames = function() {
     let regexpPortIDs = this.getRegexpPortEntries();
     if (regexpPortIDs.length == 0) {
-        return this.regexpMatchedPortInConfig = {};
+        return Promise.resolve(
+            this.regexpMatchedPortInConfig = JSON.parse(JSON.stringify(this.config.portInConfig))
+        );
     }
     return this.getActiveYarpPorts().then(function (yarpPortNames) {
         this.activeYarpPorts = yarpPortNames;

--- a/iCubTelemVizServer/configHandler.js
+++ b/iCubTelemVizServer/configHandler.js
@@ -5,6 +5,34 @@ const {evalTemplateLiteralInJSON} = require ('../common/utils');
 function ConfigHandler(configFile) {
     this.config = require(configFile);
     this.config = evalTemplateLiteralInJSON(this.config);
+    this.regexpMatchedPortInConfig = undefined;
+}
+
+/**
+ * Retrieves from the ports configuration all the port names defined through a regular
+ * expression and matches those to existing Yarp ports (Yarp ports are listed through
+ * the command `yarp name list`.
+ * Returns the array of resulting port names and also stores it in place.
+ *
+ * @returns {string[]} - array of matching Yarp port names.
+ */
+ConfigHandler.prototype.matchRegexpYarpPortNames = function() {
+    let regexpPortNames = this.getRegexpPortEntries();
+    if (regexpPortNames.length == 0) {
+        return this.regexpMatchedPortInConfig = {};
+    }
+    return this.regexpMatchedPortInConfig;
+}
+
+/**
+ * Returns the list of keys in `this.config.portInConfig` which index regexp port names.
+ *
+ * @returns {string[]} - array of keys indexing regexp port names.
+ */
+ConfigHandler.prototype.getRegexpPortEntries = function() {
+    return Object.keys(this.config.portInConfig).filter((id) => {
+        return (this.config.portInConfig[id].yarpName.match(/^\@\{.+\}$/i) !== null);
+    });
 }
 
 module.exports = ConfigHandler;

--- a/iCubTelemVizServer/configHandler.js
+++ b/iCubTelemVizServer/configHandler.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const {evalTemplateLiteralInJSON} = require ('../common/utils');
+
+function ConfigHandler(configFile) {
+    this.config = require(configFile);
+    this.config = evalTemplateLiteralInJSON(this.config);
+}
+
+module.exports = ConfigHandler;

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -63,7 +63,6 @@ var historyServer = new HistoryServer(icubtelemetry);
 app.use('/realtime', realtimeServer);
 app.use('/history', historyServer);
 
-
 Object.keys(portInConfig).forEach(function (id) {
     var portIn = yarp.portHandler.open(portInConfig[id]["localName"],portInConfig[id]["portType"]);
 
@@ -83,29 +82,31 @@ Object.keys(portInConfig).forEach(function (id) {
     }
 });
 
-// Open the Yarp ports, register read callback functions, connect the ports and start the notifier task.
-// Use topics to create persistent connections.
-icubtelemetry.defineNetworkConnector(
-    (id) => {
-        yarp.Network.connect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
-        yarp.Network.connect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-    },
-    (id) => {
-        yarp.Network.disconnect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
-        yarp.Network.disconnect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-        yarp.Network.disconnect(portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-    }
-);
-
 const TerminationHandler = require('./terminationHandler.js');
 
-Object.keys(portInConfig).forEach(function (id) {
-    // Connect the Yarp port listener to 'icubtelemetry' handler and to the robot interface.
-    // Prepare the disconnection for the server termination.
-    TerminationHandler.prototype.unlistenToNetworkPorts.push(icubtelemetry.connectTelemSrcToNotifier(id));
-});
+configHandler.matchRegexpYarpPortNames().then((matchedPortConfig) => {
+// Open the Yarp ports, register read callback functions, connect the ports and start the notifier task.
+// Use topics to create persistent connections.
+    icubtelemetry.defineNetworkConnector(
+        (id) => {
+            yarp.Network.connect(matchedPortConfig[id]["yarpName"],"topic:/" + matchedPortConfig[id]["yarpName"]);
+            yarp.Network.connect("topic:/" + matchedPortConfig[id]["yarpName"],matchedPortConfig[id]["localName"]);
+        },
+        (id) => {
+            yarp.Network.disconnect(matchedPortConfig[id]["yarpName"],"topic:/" + matchedPortConfig[id]["yarpName"]);
+            yarp.Network.disconnect("topic:/" + matchedPortConfig[id]["yarpName"],matchedPortConfig[id]["localName"]);
+            yarp.Network.disconnect(matchedPortConfig[id]["yarpName"],matchedPortConfig[id]["localName"]);
+        }
+    );
 
-icubtelemetry.startNotifier();
+    Object.keys(matchedPortConfig).forEach(function (id) {
+        // Connect the Yarp port listener to 'icubtelemetry' handler and to the robot interface.
+        // Prepare the disconnection for the server termination.
+        TerminationHandler.prototype.unlistenToNetworkPorts.push(icubtelemetry.connectTelemSrcToNotifier(id));
+    });
+
+    icubtelemetry.startNotifier();
+});
 
 // Create RPC server for executing system commands
 portRPCserver4sysCmds = yarp.portHandler.open('/yarpjs/sysCmdsGenerator/rpc','rpc');

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -85,12 +85,12 @@ Object.keys(portInConfig).forEach(function (id) {
     switch (portInConfig[id]["portType"]) {
         case 'bottle':
             portIn.onRead(function (bottle){
-                icubtelemetry.forwardYarpDataToNotifier[id](id,bottle.toArray());
+                icubtelemetry.processOrDropYarpData[id](id,bottle.toArray());
             });
             break;
         case 'image':
             portIn.onRead(function (image){
-                icubtelemetry.forwardYarpDataToNotifier[id](id,getDataURIscheme(image.getCompressionType(),image.toBinary()));
+                icubtelemetry.processOrDropYarpData[id](id,getDataURIscheme(image.getCompressionType(),image.toBinary()));
             });
             break;
         default:

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -63,21 +63,6 @@ var historyServer = new HistoryServer(icubtelemetry);
 app.use('/realtime', realtimeServer);
 app.use('/history', historyServer);
 
-// Open the Yarp ports, register read callback functions, connect the ports and start the notifier task.
-// Use topics to create persistent connections.
-icubtelemetry.defineNetworkConnector(
-  (id) => {
-      yarp.Network.connect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
-      yarp.Network.connect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-  },
-  (id) => {
-      yarp.Network.disconnect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
-      yarp.Network.disconnect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-      yarp.Network.disconnect(portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
-  }
-);
-
-const TerminationHandler = require('./terminationHandler.js');
 
 Object.keys(portInConfig).forEach(function (id) {
     var portIn = yarp.portHandler.open(portInConfig[id]["localName"],portInConfig[id]["portType"]);
@@ -96,7 +81,25 @@ Object.keys(portInConfig).forEach(function (id) {
             break;
         default:
     }
+});
 
+// Open the Yarp ports, register read callback functions, connect the ports and start the notifier task.
+// Use topics to create persistent connections.
+icubtelemetry.defineNetworkConnector(
+    (id) => {
+        yarp.Network.connect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
+        yarp.Network.connect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
+    },
+    (id) => {
+        yarp.Network.disconnect(portInConfig[id]["yarpName"],"topic:/" + portInConfig[id]["yarpName"]);
+        yarp.Network.disconnect("topic:/" + portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
+        yarp.Network.disconnect(portInConfig[id]["yarpName"],portInConfig[id]["localName"]);
+    }
+);
+
+const TerminationHandler = require('./terminationHandler.js');
+
+Object.keys(portInConfig).forEach(function (id) {
     // Connect the Yarp port listener to 'icubtelemetry' handler and to the robot interface.
     // Prepare the disconnection for the server termination.
     TerminationHandler.prototype.unlistenToNetworkPorts.push(icubtelemetry.connectTelemSrcToNotifier(id));

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -2,9 +2,10 @@
  * Server http (non secure)
  */
 
-// Import main configuration
-const {evalTemplateLiteralInJSON} = require('../common/utils');
-var config = evalTemplateLiteralInJSON(require('../conf/servers'));
+// Retrieve the main configuration
+const ConfigHandler = require('./configHandler');
+const configHandler = new ConfigHandler('../conf/servers');
+var config = configHandler.config;
 
 // require and setup basic http functionalities
 var portTelemetryReqOrigin = process.env.PORT_TLM_REQ_ORIGIN || config.openmctStaticServer.port;

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -88,7 +88,7 @@ function ICubTelemetry(portInConfig) {
         "sens.batteryStatus": {
             "voltage": 0, "current": 0, "charge": 0, "temperature": 0, "status": 0
         },
-        "processTextLogging.yarpRobotInterface": {
+        "yarplogger.yarpRobotInterface": {
             "message": "", "level": "", "filename": "", "line": 0, "function": "", "hostname": "", "pid": 0, "cmd": "", "args": "", "thread_id": 0 , "component": "", "id": "", "systemtime": 0, "networktime": 0, "externaltime": 0, "backtrace": ""
         }
     };
@@ -119,7 +119,7 @@ function ICubTelemetry(portInConfig) {
     this.state["sens.rightFootHeelFT"] = JSON.parse(JSON.stringify(this.state["sens.leftArmFT"]));
     this.state["sens.rightFootToetipFT"] = JSON.parse(JSON.stringify(this.state["sens.leftArmFT"]));
     this.state["sens.rightFootToetipFT"] = JSON.parse(JSON.stringify(this.state["sens.leftArmFT"]));
-    this.state["processTextLogging.walkingModule"] = JSON.parse(JSON.stringify(this.state["processTextLogging.yarpRobotInterface"]));
+    this.state["yarplogger.walkingModule"] = JSON.parse(JSON.stringify(this.state["yarplogger.yarpRobotInterface"]));
 
     this.parser = {};
     Object.keys(portInConfig).forEach((key) => {
@@ -341,8 +341,8 @@ ICubTelemetry.prototype.parseFromId = function (id,sensorSample) {
             this.state[id].temperature = sensorSample[3];
             this.state[id].status = sensorSample[4];
             break;
-        case "processTextLogging.yarpRobotInterface":
-        case "processTextLogging.walkingModule":
+        case "yarplogger.yarpRobotInterface":
+        case "yarplogger.walkingModule":
             // Parse hostname, pid, port.
             let pid, hostname;
             [,hostname,,pid] = sensorSample[0].match(/[^\/]*\/log\/(.+)\/(.+)\/([0-9]+)/);

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -121,7 +121,7 @@ function ICubTelemetry(portInConfig) {
     this.state["sens.rightFootToetipFT"] = JSON.parse(JSON.stringify(this.state["sens.leftArmFT"]));
     this.state["yarplogger.walkingModule"] = JSON.parse(JSON.stringify(this.state["yarplogger.yarpRobotInterface"]));
 
-    this.parseNforwardDataToNotifierOrSend = [];
+    this.parseNforwardDataToNotifierOrSend = {};
 
     this.telemetryIDsToSend = [];
 

--- a/iCubTelemVizServer/openMctServerHandlerParentProc.js
+++ b/iCubTelemVizServer/openMctServerHandlerParentProc.js
@@ -24,11 +24,16 @@ function OpenMctServerHandlerParentProc(outputCallback,errorCallback) {
     this.onCloseFailure = (errorObject) => {
         this.errorCallback('Untriggered closure: ' + errorObject.toString());
     };
+    this.refreshPortsNconnections = () => {};
 }
 
 // Old Javascript inheritance: inherit all of OpenMctServerHandlerBase'methods
 OpenMctServerHandlerParentProc.prototype = new OpenMctServerHandlerBase();
 OpenMctServerHandlerParentProc.prototype.constructor = OpenMctServerHandlerParentProc;
+
+OpenMctServerHandlerParentProc.prototype.installRefreshPorts = function (refreshPortsNconnectionsCB) {
+    this.refreshPortsNconnections = refreshPortsNconnectionsCB;
+}
 
 OpenMctServerHandlerParentProc.prototype.start = function () {
     // Check if the server is already running

--- a/openmctStaticServer/openMctServerHandlerChildProc.js
+++ b/openmctStaticServer/openMctServerHandlerChildProc.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Import comon properties for OpenMctServerHandlerParentProc and OpenMctServerHandlerChildProc
-const OpenMctServerHandlerBase = require('../common/openMctServerHandlerBase');
+const {OpenMctServerHandlerBase,Child2ParentCommands} = require('../common/openMctServerHandlerBase');
 
 function OpenMctServerHandlerChildProc(outputCallback) {
     // Old Javascript inheritance: Apply the "parent" class OpenMctServerHandlerBase
@@ -19,6 +19,14 @@ OpenMctServerHandlerChildProc.prototype.messageParentProcess = function (message
     if (process.connected) {
         process.send(message);
     }
+}
+
+// Data and commands messaging to the parent process
+OpenMctServerHandlerChildProc.prototype.reportPIDtoParent = function () {
+    this.messageParentProcess({"pid": process.pid});
+}
+OpenMctServerHandlerChildProc.prototype.requestPortsRefresh = function () {
+    this.messageParentProcess({"cmd": Child2ParentCommands.RefreshRegexpConnections});
 }
 
 module.exports = OpenMctServerHandlerChildProc;

--- a/openmctStaticServer/plugins/conf/dictionaryProcessLogging.json
+++ b/openmctStaticServer/plugins/conf/dictionaryProcessLogging.json
@@ -1,0 +1,175 @@
+{
+  "name": "Process Logging",
+  "key": "processLogging",
+  "presetValuesBase": {
+    "yarpLoggerMessage": [
+      {
+        "key": "value.message",
+        "name": "Message",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 1
+        }
+      },
+      {
+        "key": "value.level",
+        "name": "Level",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 2
+        }
+      },
+      {
+        "key": "value.filename",
+        "name": "File name",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 3
+        }
+      },
+      {
+        "key": "value.line",
+        "name": "Line",
+        "unit": "",
+        "format": "int",
+        "hints": {
+          "range": 4
+        }
+      },
+      {
+        "key": "value.function",
+        "name": "Function",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 5
+        }
+      },
+      {
+        "key": "value.hostname",
+        "name": "Host name",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 6
+        }
+      },
+      {
+        "key": "value.pid",
+        "name": "PID",
+        "unit": "",
+        "format": "int",
+        "hints": {
+          "range": 7
+        }
+      },
+      {
+        "key": "value.cmd",
+        "name": "Command",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 8
+        }
+      },
+      {
+        "key": "value.args",
+        "name": "Arguments",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 9
+        }
+      },
+      {
+        "key": "value.thread_id",
+        "name": "Thread ID",
+        "unit": "",
+        "format": "int",
+        "hints": {
+          "range": 10
+        }
+      },
+      {
+        "key": "value.component",
+        "name": "Component",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 11
+        }
+      },
+      {
+        "key": "value.id",
+        "name": "ID",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 12
+        }
+      },
+      {
+        "key": "value.systemtime",
+        "name": "System time",
+        "unit": "s",
+        "format": "float",
+        "hints": {
+          "range": 12
+        }
+      },
+      {
+        "key": "value.networktime",
+        "name": "Network time",
+        "unit": "s",
+        "format": "float",
+        "hints": {
+          "range": 12
+        }
+      },
+      {
+        "key": "value.externaltime",
+        "name": "External time",
+        "unit": "s",
+        "format": "float",
+        "hints": {
+          "range": 12
+        }
+      },
+      {
+        "key": "value.backtrace",
+        "name": "Back trace",
+        "unit": "",
+        "format": "string",
+        "hints": {
+          "range": 12
+        }
+      },
+      {
+        "key": "utc",
+        "source": "timestamp",
+        "name": "Timestamp",
+        "format": "utc",
+        "hints": {
+          "domain": 1
+        }
+      }
+    ]
+  },
+  "telemetryEntries": [
+    {
+      "name": "yarprobotinterface process logging through yarplogger",
+      "key": "yarplogger.yarpRobotInterface",
+      "type": "yarpopenmct.yarptextlog",
+      "values": "${JSON.stringify(this.presetValuesBase.yarpLoggerMessage)}"
+    },
+    {
+      "name": "WalkingModule process logging through yarplogger",
+      "key": "yarplogger.walkingModule",
+      "type": "yarpopenmct.yarptextlog",
+      "values": "${JSON.stringify(this.presetValuesBase.yarpLoggerMessage)}"
+    }
+  ]
+}

--- a/openmctStaticServer/plugins/conf/domainObjTypes.js
+++ b/openmctStaticServer/plugins/conf/domainObjTypes.js
@@ -58,6 +58,16 @@ const DOMAIN_OBJECTS_TYPES = {
             },
             domain: {}
         }
+    },
+    "yarpopenmct.yarptextlog": {
+        name: 'Yarp Text Logging Message',
+        description: 'Process log message forwarded to the YarpLogger on a Yarp port /log/hostname/processname[YARP_LOG_PROCESS_LABEL]/pid.',
+        icon: 'icon-info',
+        reportSchedule: [ReportSchedule.Realtime,ReportSchedule.Historical],
+        telemetryMetadataDflt: {
+            range: {},
+            domain: {}
+        }
     }
 };
 

--- a/openmctStaticServer/plugins/dictionary-plugin.js
+++ b/openmctStaticServer/plugins/dictionary-plugin.js
@@ -15,11 +15,11 @@ function requestLatestTelemetrySample(telemetryEntryKey) {
 function getDictionary(identifier) {
     if (namespace2dictionaryFile[identifier.namespace] !== undefined) {
         return http.get(namespace2dictionaryFile[identifier.namespace])
-                .then(function (result) {
-                    return result.data;
-                });
+            .then(function (result) {
+                return result.data;
+            });
     } else {
-            return Promise.reject('Unknown namespace!!');
+        return Promise.reject('Unknown namespace!!');
     }
 }
 
@@ -70,7 +70,8 @@ class ObjectProvider {
 var compositionProvider = {
     appliesTo: function (domainObject) {
         return (domainObject.identifier.namespace === ICUBTELEMETRY_DOMAIN_OBJECTS_NAMESPACE
-            || domainObject.identifier.namespace === VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE)
+            || domainObject.identifier.namespace === VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE
+            || domainObject.identifier.namespace === PROCESSLOGGING_DOMAIN_OBJECTS_NAMESPACE)
             && domainObject.type === 'folder';
     },
     load: function (domainObject) {
@@ -105,6 +106,13 @@ function DictionaryPlugin(telemServerHost,telemServerPort) {
         });
 
         openmct.objects.addProvider(ICUBTELEMETRY_DOMAIN_OBJECTS_NAMESPACE, new ObjectProvider());
+
+        openmct.objects.addRoot({
+            namespace: PROCESSLOGGING_DOMAIN_OBJECTS_NAMESPACE,
+            key: 'processLogging'
+        });
+
+        openmct.objects.addProvider(PROCESSLOGGING_DOMAIN_OBJECTS_NAMESPACE, new ObjectProvider());
 
         openmct.objects.addRoot({
             namespace: VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE,

--- a/openmctStaticServer/plugins/dictionary-plugin.js
+++ b/openmctStaticServer/plugins/dictionary-plugin.js
@@ -13,18 +13,12 @@ function requestLatestTelemetrySample(telemetryEntryKey) {
 }
 
 function getDictionary(identifier) {
-    switch (identifier.namespace) {
-        case ICUBTELEMETRY_DOMAIN_OBJECTS_NAMESPACE:
-            return http.get('plugins/conf/dictionaryIcubTelemetry.json')
+    if (namespace2dictionaryFile[identifier.namespace] !== undefined) {
+        return http.get(namespace2dictionaryFile[identifier.namespace])
                 .then(function (result) {
                     return result.data;
                 });
-        case VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE:
-            return http.get('config/dictionaryVectorCollectionsTelemetry.json')
-                .then(function (result) {
-                    return result.data;
-                });
-        default:
+    } else {
             return Promise.reject('Unknown namespace!!');
     }
 }

--- a/openmctStaticServer/plugins/namespacesNtypes.js
+++ b/openmctStaticServer/plugins/namespacesNtypes.js
@@ -1,9 +1,11 @@
 const ICUBTELEMETRY_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.icubtelemetry';
 const VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.vectorCollectionsTelemetry';
+const PROCESSLOGGING_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.processLogging';
 
 const namespace2dictionaryFile = {
     'yarpopenmct.icubtelemetry': 'plugins/conf/dictionaryIcubTelemetry.json',
-    'yarpopenmct.vectorCollectionsTelemetry': 'config/dictionaryVectorCollectionsTelemetry.json'
+    'yarpopenmct.vectorCollectionsTelemetry': 'config/dictionaryVectorCollectionsTelemetry.json',
+    'yarpopenmct.processLogging': 'config/dictionaryProcessLogging.json'
 }
 Object.freeze(namespace2dictionaryFile);
 

--- a/openmctStaticServer/plugins/namespacesNtypes.js
+++ b/openmctStaticServer/plugins/namespacesNtypes.js
@@ -5,7 +5,7 @@ const PROCESSLOGGING_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.processLogging';
 const namespace2dictionaryFile = {
     'yarpopenmct.icubtelemetry': 'plugins/conf/dictionaryIcubTelemetry.json',
     'yarpopenmct.vectorCollectionsTelemetry': 'config/dictionaryVectorCollectionsTelemetry.json',
-    'yarpopenmct.processLogging': 'config/dictionaryProcessLogging.json'
+    'yarpopenmct.processLogging': 'plugins/conf/dictionaryProcessLogging.json'
 }
 Object.freeze(namespace2dictionaryFile);
 

--- a/openmctStaticServer/plugins/namespacesNtypes.js
+++ b/openmctStaticServer/plugins/namespacesNtypes.js
@@ -1,5 +1,12 @@
 const ICUBTELEMETRY_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.icubtelemetry';
 const VECTORCOLLECTIONS_DOMAIN_OBJECTS_NAMESPACE = 'yarpopenmct.vectorCollectionsTelemetry';
+
+const namespace2dictionaryFile = {
+    'yarpopenmct.icubtelemetry': 'plugins/conf/dictionaryIcubTelemetry.json',
+    'yarpopenmct.vectorCollectionsTelemetry': 'config/dictionaryVectorCollectionsTelemetry.json'
+}
+Object.freeze(namespace2dictionaryFile);
+
 class ReportSchedule {
     static Realtime = Symbol();
     static Historical = Symbol();

--- a/openmctStaticServer/server.js
+++ b/openmctStaticServer/server.js
@@ -5,6 +5,7 @@
 // Import main configuration and dynamic dictionaries
 confServers = require('../conf/servers');
 dictionaryIcubtelemetry = require('./plugins/conf/dictionaryIcubTelemetry');
+dictionaryProcessLogging = require('./plugins/conf/dictionaryProcessLogging');
 
 // Send the process PID back to the parent through the IPC channel
 const OpenMctServerHandlerChildProc = require('./openMctServerHandlerChildProc');
@@ -21,6 +22,7 @@ const {
 const confServersJSON = evalTemplateLiteralInJSON(confServers);
 const expandedDictionaryIcubtelemetry = expandTelemetryDictionary(dictionaryIcubtelemetry);
 const dictionaryIcubtelemetryJSON = evalTemplateLiteralInJSON(expandedDictionaryIcubtelemetry);
+const dictionaryProcessLoggingJSON = evalTemplateLiteralInJSON(dictionaryProcessLogging);
 const app = require('express')();
 expressWs(app);
 
@@ -31,6 +33,9 @@ app.get('/config/confServers.json', function(req, res){
 });
 app.get('/plugins/conf/dictionaryIcubTelemetry.json', function(req, res){
     res.send(dictionaryIcubtelemetryJSON);
+});
+app.get('/plugins/conf/dictionaryProcessLogging.json', function(req, res){
+    res.send(dictionaryProcessLoggingJSON);
 });
 
 // Route static server

--- a/openmctStaticServer/server.js
+++ b/openmctStaticServer/server.js
@@ -4,7 +4,7 @@
 
 // Import main configuration and dynamic dictionaries
 confServers = require('../conf/servers');
-dictionary = require('./plugins/conf/dictionaryIcubTelemetry');
+dictionaryIcubtelemetry = require('./plugins/conf/dictionaryIcubTelemetry');
 
 // Send the process PID back to the parent through the IPC channel
 const OpenMctServerHandlerChildProc = require('./openMctServerHandlerChildProc');
@@ -19,8 +19,8 @@ const {
     expandTelemetryDictionary
 } = require("../common/utils");
 const confServersJSON = evalTemplateLiteralInJSON(confServers);
-const expandedDictionary = expandTelemetryDictionary(dictionary);
-const dictionaryJSON = evalTemplateLiteralInJSON(expandedDictionary);
+const expandedDictionaryIcubtelemetry = expandTelemetryDictionary(dictionaryIcubtelemetry);
+const dictionaryIcubtelemetryJSON = evalTemplateLiteralInJSON(expandedDictionaryIcubtelemetry);
 const app = require('express')();
 expressWs(app);
 
@@ -30,7 +30,7 @@ app.get('/config/confServers.json', function(req, res){
     res.send(jsonExportScript(confServersJSON,'confServers'));
 });
 app.get('/plugins/conf/dictionaryIcubTelemetry.json', function(req, res){
-    res.send(dictionaryJSON);
+    res.send(dictionaryIcubtelemetryJSON);
 });
 
 // Route static server

--- a/openmctStaticServer/server.js
+++ b/openmctStaticServer/server.js
@@ -10,7 +10,7 @@ dictionaryProcessLogging = require('./plugins/conf/dictionaryProcessLogging');
 // Send the process PID back to the parent through the IPC channel
 const OpenMctServerHandlerChildProc = require('./openMctServerHandlerChildProc');
 const procHandler = new OpenMctServerHandlerChildProc(console.log,console.error);
-procHandler.messageParentProcess({"pid": process.pid});
+procHandler.reportPIDtoParent();
 
 const StaticServer = require('./static-server');
 const expressWs = require('express-ws');
@@ -28,6 +28,16 @@ expressWs(app);
 
 const staticServer = new StaticServer();
 // Process default server configuration requests
+
+// The default page request processing is defined by default, but redefined here for triggering a refresh of the port
+// connections.
+app.get('/', function(req, res){
+    res.sendFile('index.html',{ root : __dirname});
+    if (!procHandler.requestPortsRefresh()) {
+        console.warn('Ports refresh request not sent!');
+    }
+});
+
 app.get('/config/confServers.json', function(req, res){
     res.send(jsonExportScript(confServersJSON,'confServers'));
 });


### PR DESCRIPTION
Implements #138 .

## Step 1: Add ports, parsing and notification of Yarp Text Logging data (no auto search for the ports streaming the Yarp text logging)

In a first step we focus on the data parsing and sending to the visualizer, the dictionary definition and the actual data visualisation in the OpenMCT framework. For this purpose, the port names are fully defined in the configuration file `servers.js`, and edited every time the processes logging the data (`yarprobotinterface`, `WalkingModule`) are stopped and run again. => commits c9b285d837ed23d071b514f688bd734525736b2d to 126edf941d1448ba552ce3820859a1df3242c69b included.

#### In the configuration file
- [x] Add the Yarprobotinterface and WalkingController logging ports to the port configuration.

On the telemetry server:
- [x] Add the Yarp Text Logging to the `state` buffer.
- [x] Add the parsing of the data to the main parser.

#### On OpenMCT framework
- [x] Add a new folder "Modules process output logging".
- [x] Add to the folder the two new entries related to the Yarprobotinterface and WalkingController processes.
- [x] Add the respective dictionary and set the appropriate data type and format.
- [x] Use plugin "Telemetry Table" to display the log data.

**Note:** There is a pop-up window when we hover above a given datum, and we have a "view full datum" option.

## Step 2: Improved Version: auto search for ports streaming the logged data and refresh the connections

#### In the configuration file
- [x] We replace the full port names by a syntax[^*] which is then evaluated by the telemetry server as a regular expression for matching existing Yarp ports. The user can integrate in the regexp the `YARP_LOG_PROCESS_LABEL` of his choice for matching the ports streaming the logging data from`yarprobotinterface` and `WalkingModule` modules.

[^*]: The syntax is as follows: the pattern `"@{...}"` wraps a regular expression which, once unwrapped, can be directly interpreted by the Javascript code.

#### On the telemetry server
(Re)connect the Yarp text logging  ports as soon as the client page is refreshed (servers.json config is reloaded)
- [x] Trigger the operation in the config file `servers.json` route function.
- [x] Build a list of all the port names integrating a regexp: `<regexp-port-names-list>`.
- [x] If `<regexp-port-names-list>` is empty, return, otherwise continue.
- [x] Disconnect all the existing telemetry port connections.
- [x] Run a full scan of the existing Yarp ports => `<yarp-ports-list>`.
- [x] For each port found in `<regexp-port-names-list>`, get the Yarp port name from `<yarp-ports-list>` matching the regexp pattern => `<matched-yarp-remote-ports-list>`.
- [x] For each port in `<matched-yarp-remote-ports-list>`:
    - [x] ~Check if the respective `<yarpjs-local-port>` port exists => if not, create it.~ We consider that these didn't change, otherwise just restart the telemetry server.
    - [x] Connect `<yarp-remote-port>` to `<yarpjs-local-port>`.
- [x] Trigger the regexp ports reconnection in the config file `servers.json` route function.

Below is an example of the displayed "Process Logging" folder and the contained Yarp Text Logging entries.

![image](https://user-images.githubusercontent.com/6848872/192646294-2bc3eb1a-de5e-4949-b707-f4831c827728.png)
