### PR TITLE
[openmctStaticServer] Handle socket.send `still connecting` error for fixing page refresh

### DIFF
--- a/openmctStaticServer/plugins/realtime-telemetry-plugin.js
+++ b/openmctStaticServer/plugins/realtime-telemetry-plugin.js
@@ -19,7 +19,13 @@ function RealtimeTelemetryPlugin(telemServerHost,telemServerPort) {
             },
             subscribe: function (domainObject, callback) {
                 listener[domainObject.identifier.key] = callback;
-                socket.send('subscribe ' + domainObject.identifier.key);
+                try {
+                    socket.send('subscribe ' + domainObject.identifier.key);
+                } catch(errorMessage) {
+                    console.error(errorMessage);
+                    delete listener[domainObject.identifier.key];
+                    return function unsubscribe() {};
+                }
                 return function unsubscribe() {
                     delete listener[domainObject.identifier.key];
                     socket.send('unsubscribe ' + domainObject.identifier.key);


### PR DESCRIPTION
Improves fix #147 .

Refer to comment https://github.com/ami-iit/yarp-openmct/issues/147#issuecomment-1401365054.

(last PR, for the sake of completion...)